### PR TITLE
Per Task Retry-Policy

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -147,6 +147,30 @@ class Task(object):
     worker_timeout = None
 
     @property
+    def retry_count(self):
+        """
+        Override this positive integer to have different ``retry_count`` at task level
+        Check :ref:`scheduler-config`
+        """
+        return None
+
+    @property
+    def disable_hard_timeout(self):
+        """
+        Override this positive integer to have different ``disable_hard_timeout`` at task level.
+        Check :ref:`scheduler-config`
+        """
+        return None
+
+    @property
+    def disable_window_seconds(self):
+        """
+        Override this positive integer to have different ``disable_window_seconds`` at task level.
+        Check :ref:`scheduler-config`
+        """
+        return None
+
+    @property
     def owner_email(self):
         '''
         Override this to send out additional error emails to task owner, in addition to the one

--- a/test/db_task_history_test.py
+++ b/test/db_task_history_test.py
@@ -93,7 +93,7 @@ class DbTaskHistoryTest(unittest.TestCase):
 
     def run_task(self, task):
         task2 = luigi.scheduler.Task(task.task_id, PENDING, [], family=task.task_family,
-                                     params=task.param_kwargs)
+                                     params=task.param_kwargs, retry_policy=luigi.scheduler._get_empty_retry_policy())
 
         self.history.task_scheduled(task2)
         self.history.task_started(task2, 'hostname')
@@ -133,7 +133,8 @@ class MySQLDbTaskHistoryTest(unittest.TestCase):
 
     def run_task(self, task):
         task2 = luigi.scheduler.Task(task.task_id, PENDING, [],
-                                     family=task.task_family, params=task.param_kwargs)
+                                     family=task.task_family, params=task.param_kwargs,
+                                     retry_policy=luigi.scheduler._get_empty_retry_policy())
 
         self.history.task_scheduled(task2)
         self.history.task_started(task2, 'hostname')

--- a/test/scheduler_api_test.py
+++ b/test/scheduler_api_test.py
@@ -42,7 +42,7 @@ class SchedulerApiTest(unittest.TestCase):
             'worker_disconnect_delay': 10,
             'disable_persist': 10,
             'disable_window': 10,
-            'disable_failures': 3,
+            'retry_count': 3,
             'disable_hard_timeout': 60 * 60,
         }
 
@@ -742,7 +742,7 @@ class SchedulerApiTest(unittest.TestCase):
         self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], 'A')
 
     def test_automatic_re_enable(self):
-        self.sch = Scheduler(disable_failures=2, disable_persist=100)
+        self.sch = Scheduler(retry_count=2, disable_persist=100)
         self.setTime(0)
         self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
         self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
@@ -755,7 +755,7 @@ class SchedulerApiTest(unittest.TestCase):
         self.assertEqual(FAILED, self.sch.task_list('', '')['A']['status'])
 
     def test_automatic_re_enable_with_one_failure_allowed(self):
-        self.sch = Scheduler(disable_failures=1, disable_persist=100)
+        self.sch = Scheduler(retry_count=1, disable_persist=100)
         self.setTime(0)
         self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
 
@@ -779,7 +779,7 @@ class SchedulerApiTest(unittest.TestCase):
         self.assertEqual(DISABLED, self.sch.task_list('', '')['A']['status'])
 
     def test_no_automatic_re_enable_after_auto_then_manual_disable(self):
-        self.sch = Scheduler(disable_failures=2, disable_persist=100)
+        self.sch = Scheduler(retry_count=2, disable_persist=100)
         self.setTime(0)
         self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
         self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)

--- a/test/worker_keep_alive_test.py
+++ b/test/worker_keep_alive_test.py
@@ -33,7 +33,7 @@ class WorkerKeepAliveUpstreamTest(LuigiTestCase):
         """
         Common setup code. Due to the contextmanager cant use normal setup
         """
-        self.sch = Scheduler(retry_delay=0.00000001, disable_failures=2)
+        self.sch = Scheduler(retry_delay=0.00000001, retry_count=2)
 
         with Worker(scheduler=self.sch, worker_id='X', keep_alive=True, wait_interval=0.1, wait_jitter=0) as w:
             self.w = w


### PR DESCRIPTION
Recreated from original PR: https://github.com/spotify/luigi/pull/1791

<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->
## Description

Defining retry-policy per task as it is defined in #1073 
## Motivation and Context

It may be required to have different retry-policy for different tasks according to their priority and resource usage. Assume that, a task is retrieving data from Hive which responses in long time and other one is retrieving data from RDBM...